### PR TITLE
Version 0.10

### DIFF
--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -1,4 +1,4 @@
-# Heroku buildpack for [PredictionIO](http://predictionio.incubator.apache.org) 0.9.5
+# Heroku buildpack for [PredictionIO](http://predictionio.incubator.apache.org)
 
 👓 Requires intermediate technical skills working with PredictionIO engines.
 
@@ -75,7 +75,7 @@ heroku pg:wait && git push heroku master
 
 Select an engine from the [gallery](https://predictionio.incubator.apache.org/gallery/template-gallery/). Download a `.tar.gz` from Github and open/expand it on your local computer.
 
-🏷 This buildpack is compatible with templates built for **PredictionIO version 0.9**
+🏷 This buildpack is compatible with templates built for **PredictionIO version 0.9 & 0.10**. The appropriate version of PredictionIO will be automatically use based on the version declared in `template.json`.
 
 🚨 Avoid engines that persist their model to the filesystem, which is incompatible with the [emphermeral filesystem](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem) of Heroku dynos. These engines must be modified to use Amazon S3 or the database for persistence. 
 
@@ -277,7 +277,7 @@ Check engine status:
 heroku run pio status
 ```
 
-#### Fix for database connectivity with PredictionIO 0.9 
+#### Fix for database connectivity with PredictionIO 0.9.5
 
 `pio` commands that require DB access will need to have the driver specified as an argument (bug with PIO 0.9.5 + Spark 1.6.1):
 

--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -263,16 +263,10 @@ Engine deployments honor the following config vars:
 
 ## Running commands
 
-`pio` commands that require DB access will need to have the driver specified as an argument (bug with PIO 0.9.5 + Spark 1.6.1):
-
-```bash
-pio $command -- --driver-class-path /app/lib/postgresql_jdbc.jar
-```
-
 #### To run directly with Heroku CLI
 
 ```bash
-heroku run "cd pio-engine && pio $command -- --driver-class-path /app/lib/postgresql_jdbc.jar"
+heroku run pio $command
 ```
 
 #### Useful commands
@@ -280,6 +274,14 @@ heroku run "cd pio-engine && pio $command -- --driver-class-path /app/lib/postgr
 Check engine status:
 
 ```bash
-heroku run "cd pio-engine && pio status -- --driver-class-path /app/lib/postgresql_jdbc.jar"
+heroku run pio status
+```
+
+#### Fix for database connectivity with PredictionIO 0.9 
+
+`pio` commands that require DB access will need to have the driver specified as an argument (bug with PIO 0.9.5 + Spark 1.6.1):
+
+```bash
+pio $command -- --driver-class-path /app/lib/postgresql_jdbc.jar
 ```
 

--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -172,13 +172,18 @@ heroku restart
 
 ## Scale up
 
-Once deployed, scale up the processes to avoid memory issues:
+Once deployed, scale up the processes and config Spark to avoid memory issues:
 
 ```bash
 heroku ps:scale \
   web=1:Performance-M \
   release=0:Performance-L \
   train=0:Performance-L
+
+# Fit Spark memory usage to those dyno types
+heroku config:set \
+  PIO_SPARK_OPTS='--executor-memory 1g' \
+  PIO_TRAIN_SPARK_OPTS='--executor-memory 10g'
 ```
 
 ## Evaluation

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ heroku logs -t --app $engine_name
 
 ## Scale up
 
-Once deployed, scale up the processes to avoid memory issues:
+Once deployed, scale up the processes and config Spark to avoid memory issues:
 
 ```bash
 heroku ps:scale \
@@ -153,6 +153,11 @@ heroku ps:scale \
   release=0:Performance-L \
   train=0:Performance-L \
   --app $engine_name
+
+# Fit Spark memory usage to those dyno types
+heroku config:set \
+  PIO_SPARK_OPTS='--executor-memory 768m' \
+  PIO_TRAIN_SPARK_OPTS='--executor-memory 10g'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Predictive classification powered by [PredictionIO](https://predictionio.incubator.apache.org), machine learning on [Heroku](http://www.heroku.com).
 
-This is a demo application of PredictionIO version 0.9.5 preset for simplified deployment. **Custom PredictionIO engines** may be deployed as well, see [CUSTOM documentation](CUSTOM.md).
+This is a demo application of PredictionIO preset for simplified deployment. **Custom PredictionIO engines** may be deployed as well, see [CUSTOM documentation](CUSTOM.md).
 
 Once deployed, this engine demonstrates prediction of the best fitting **service plan** for a **mobile phone user** based on their **voice, data, and text usage**. The model is trained with a small, example data set.
 

--- a/bin/compile
+++ b/bin/compile
@@ -64,22 +64,21 @@ BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 
 if [ $(requires_apache_predictionio "$BUILD_DIR/template.json") ]
 then
-  topic "Detected Apache PredictionIO template (>= 0.10)"
-  # Original build for PredictionIO 0.9.5
-  PIO_VERSION=0.10.0
-  PIO_BUILD=PredictionIO-${PIO_VERSION}-incubating
+  PIO_VERSION=0.10.0-incubating
   SPARK_VERSION=spark-1.6.2-bin-hadoop2.6
   # No special PostgreSQL driver is required
   POSTGRESQL_DRIVER=''
+  echo "Using Apache PredictionIO ${PIO_VERSION}" | indent
 else
-  topic "Detected old PredictionIO template (<= 0.9)"
   mkdir -p "$BUILD_DIR/.heroku"
   echo '# Presence of this file indicates a pre-Apache engine (<= 0.9)' > "$BUILD_DIR/.heroku/.is_old_predictionio"
   PIO_VERSION=0.9.5
-  PIO_BUILD=PredictionIO-${PIO_VERSION}
   SPARK_VERSION=spark-1.6.2-bin-hadoop2.6
   POSTGRESQL_DRIVER=postgresql-9.4.1209.jar
+  echo "Using PredictionIO $PIO_VERSION" | indent
 fi
+
+PIO_BUILD=PredictionIO-${PIO_VERSION}
 
 
 # PredictionIO dist tarball URL, expects `.tar.gz` 

--- a/bin/compile
+++ b/bin/compile
@@ -30,10 +30,16 @@ function indent() {
 # returns 'true', and otherwise '' (empty string)
 requires_apache_predictionio() {
   local template_json=$1
-  cat $template_json | ruby \
-    -E utf-8:utf-8 \
-    -r json \
-    -e "version = JSON.parse(STDIN.read)['pio']['version']['min']; major,minor = version.split('.').map(&:to_i); STDOUT << (major>=0 && minor>=10 ? 'true' : '')"
+  if [ -e $template_json ]
+  then
+    cat $template_json | ruby \
+      -E utf-8:utf-8 \
+      -r json \
+      -e "version = JSON.parse(STDIN.read)['pio']['version']['min']; major,minor = version.split('.').map(&:to_i); STDOUT << (major>=0 && minor>=10 ? 'true' : '')"
+  else
+    # without a template file, assume we're build the eventserver on the newest version
+    echo 'true'
+  fi
 }
 
 export_env_dir() {

--- a/bin/compile
+++ b/bin/compile
@@ -9,11 +9,6 @@ set -u
 # Debug, echo every command
 #set -x
 
-PIO_VERSION=0.9.5
-PIO_BUILD=PredictionIO-${PIO_VERSION}
-SPARK_VERSION=spark-1.6.2-bin-hadoop2.6
-POSTGRESQL_DRIVER=postgresql-9.4.1209.jar
-
 function error() {
   echo " !     $*" >&2
   exit 1
@@ -29,6 +24,16 @@ function indent() {
     Darwin) sed -l "$c";;
     *)      sed -u "$c";;
   esac
+}
+
+# If the engine requires the newer Apache distribution
+# returns 'true', and otherwise '' (empty string)
+requires_apache_predictionio() {
+  local template_json=$1
+  cat $template_json | ruby \
+    -E utf-8:utf-8 \
+    -r json \
+    -e "version = JSON.parse(STDIN.read)['pio']['version']['min']; major,minor = version.split('.').map(&:to_i); STDOUT << (major>=0 && minor>=10 ? 'true' : '')"
 }
 
 export_env_dir() {
@@ -50,8 +55,29 @@ CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
 
+
+if [ $(requires_apache_predictionio "$BUILD_DIR/template.json") ]
+then
+  topic "Detected Apache PredictionIO template (>= 0.10)"
+  # Original build for PredictionIO 0.9.5
+  PIO_VERSION=0.10.0
+  PIO_BUILD=PredictionIO-${PIO_VERSION}-incubating
+  SPARK_VERSION=spark-1.6.2-bin-hadoop2.6
+  # No special PostgreSQL driver is required
+  POSTGRESQL_DRIVER=''
+else
+  topic "Detected old PredictionIO template (<= 0.9)"
+  mkdir -p "$BUILD_DIR/.heroku"
+  echo '# Presence of this file indicates a pre-Apache engine (<= 0.9)' > "$BUILD_DIR/.heroku/.is_old_predictionio"
+  PIO_VERSION=0.9.5
+  PIO_BUILD=PredictionIO-${PIO_VERSION}
+  SPARK_VERSION=spark-1.6.2-bin-hadoop2.6
+  POSTGRESQL_DRIVER=postgresql-9.4.1209.jar
+fi
+
+
 # PredictionIO dist tarball URL, expects `.tar.gz` 
-default_url="https://s3-us-west-2.amazonaws.com/download.prediction.io/${PIO_BUILD}.tar.gz"
+default_url="https://marsikai.s3.amazonaws.com/${PIO_BUILD}.tar.gz"
 export_env_dir "$ENV_DIR" '^PREDICTIONIO_DIST_URL$'
 url="${PREDICTIONIO_DIST_URL-$default_url}"
 
@@ -133,6 +159,9 @@ else
   echo 'No engine to build. (`engine.json` does not exist.)' | indent
 fi
 
-topic "Install PostgreSQL database driver"
-mkdir -p "${BUILD_DIR}/lib"
-curl -s -L "https://marsikai.s3.amazonaws.com/$POSTGRESQL_DRIVER" > "${BUILD_DIR}/lib/postgresql_jdbc.jar"
+if [ "$POSTGRESQL_DRIVER" ]
+then
+  topic "Install PostgreSQL database driver"
+  mkdir -p "${BUILD_DIR}/lib"
+  curl -s -L "https://marsikai.s3.amazonaws.com/$POSTGRESQL_DRIVER" > "${BUILD_DIR}/lib/postgresql_jdbc.jar"
+fi

--- a/bin/engine/heroku-buildpack-pio-train
+++ b/bin/engine/heroku-buildpack-pio-train
@@ -3,4 +3,9 @@
 # Fail immediately on non-zero exit code.
 set -e
 
-eval "cd /app/pio-engine && pio train ${PIO_OPTS:-} -- --driver-class-path /app/lib/postgresql_jdbc.jar ${PIO_TRAIN_SPARK_OPTS:-}"
+if [ -e "/app/.heroku/.is_old_predictionio" ]
+then
+  eval "cd /app/pio-engine && pio train ${PIO_OPTS:-} -- --driver-class-path /app/lib/postgresql_jdbc.jar ${PIO_TRAIN_SPARK_OPTS:-}"
+else
+  eval "cd /app/pio-engine && pio train ${PIO_OPTS:-} -- ${PIO_TRAIN_SPARK_OPTS:-}"
+fi

--- a/bin/engine/heroku-buildpack-pio-web
+++ b/bin/engine/heroku-buildpack-pio-web
@@ -3,4 +3,9 @@
 # Fail immediately on non-zero exit code.
 set -e
 
-eval "cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_HOSTNAME --event-server-port $PIO_EVENTSERVER_PORT --accesskey $PIO_EVENTSERVER_ACCESS_KEY ${PIO_OPTS:-} -- --driver-class-path /app/lib/postgresql_jdbc.jar ${PIO_SPARK_OPTS:-}"
+if [ -e "/app/.heroku/.is_old_predictionio" ]
+then
+  eval "cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_HOSTNAME --event-server-port $PIO_EVENTSERVER_PORT --accesskey $PIO_EVENTSERVER_ACCESS_KEY ${PIO_OPTS:-} -- --driver-class-path /app/lib/postgresql_jdbc.jar ${PIO_SPARK_OPTS:-}"
+else
+  eval "cd pio-engine/ && pio deploy --port $PORT --event-server-ip $PIO_EVENTSERVER_HOSTNAME --event-server-port $PIO_EVENTSERVER_PORT --accesskey $PIO_EVENTSERVER_ACCESS_KEY ${PIO_OPTS:-} -- ${PIO_SPARK_OPTS:-}"
+fi

--- a/config/pio-env-12f.sh
+++ b/config/pio-env-12f.sh
@@ -11,7 +11,11 @@
 # Must match $spark_dist_dir in bin.compile
 SPARK_HOME=/app/pio-engine/PredictionIO-dist/vendors/spark-hadoop
 
-POSTGRES_JDBC_DRIVER=/app/lib/postgresql_jdbc.jar
+
+if [ -e "/app/.heroku/.is_old_predictionio" ]
+then
+  POSTGRES_JDBC_DRIVER=/app/lib/postgresql_jdbc.jar
+fi
 
 # ES_CONF_DIR: You must configure this if you have advanced configuration for
 #              your Elasticsearch setup.


### PR DESCRIPTION
Backward-compatible support for the new Apache PredictionIO release, to avoid breaking existing PIO 0.9.5 deployments.

Here's the related demo classification engine update: https://github.com/heroku/predictionio-engine-classification/pull/3