### PR TITLE
Make env wrapper reusable

### DIFF
--- a/bin/local/dotenv.erb
+++ b/bin/local/dotenv.erb
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Use the PredictionIO local dev environment in any script
+# by sourcing this file:
+#
+#  `source bin/dotenv`
+#
+
+# Exit failure on any error
+set -e
+
+# Debug, echoes every command
+#set -x
+
+# This value is rendered by Ruby/ERB in the 
+# buildpack's `bin/local/setup`
+PIO_BUILDPACK_DIR="<%= ENV['PIO_BUILDPACK_DIR'] %>"
+
+# Load environment variables & render configs.
+QUIET_ENV=true
+source $PIO_BUILDPACK_DIR/bin/local/env

--- a/bin/local/pio
+++ b/bin/local/pio
@@ -6,13 +6,8 @@ set -e
 # Debug, echoes every command
 #set -x
 
-# This value is rendered by Ruby/ERB in the 
-# buildpack's `bin/local/setup`
-PIO_BUILDPACK_DIR="<%= ENV['PIO_BUILDPACK_DIR'] %>"
-
 # Load environment variables & render configs.
-QUIET_ENV=true
-source $PIO_BUILDPACK_DIR/bin/local/env
+source bin/dotenv
 
 # Invoke the real `pio` (installed by `bin/local/setup`)
 # with the original arguments.

--- a/bin/local/setup
+++ b/bin/local/setup
@@ -28,9 +28,12 @@ $BP_DIR/bin/common/setup-runtime "$BUILD_DIR" "$BP_DIR"
 mkdir -p $BUILD_DIR/bin
 # Set this directory path for the ERB template.
 export PIO_BUILDPACK_DIR="$BP_DIR"
-echo "-----> Installing \`bin/pio\`"
+echo "-----> Installing \`bin/dotenv\`"
 echo "       with environment ${PIO_BUILDPACK_DIR}/bin/local/env"
-erb $BP_DIR/bin/local/pio.erb > $BUILD_DIR/bin/pio
+erb $BP_DIR/bin/local/dotenv.erb > $BUILD_DIR/bin/dotenv
+chmod +x $BUILD_DIR/bin/dotenv
+echo "-----> Installing \`bin/pio\` local dev command"
+cp $BP_DIR/bin/local/pio $BUILD_DIR/bin/pio
 chmod +x $BUILD_DIR/bin/pio
 
 echo
@@ -44,4 +47,6 @@ echo 'PredictionIO is setup 🐸'
 echo 'Use it with:'
 echo
 echo '  bin/pio'
+echo
+echo 'Any script or shell may load the env with `source bin/dotenv`'
 echo


### PR DESCRIPTION
Extract the env loader to a new `bin/dotenv` script.

This makes the PredictionIO environment loader able to be used in additional scripts and to load env directly into a terminal:

```bash
source bin/dotenv
```