### PR TITLE
Remove all `pio-engine/` path prefixing.

### DIFF
--- a/.profile.d/pio-path.sh
+++ b/.profile.d/pio-path.sh
@@ -5,4 +5,4 @@
 # * just the distribution's bin/ (for the eventserver)
 # * also access to the `sbt` executable that is include in the distribution
 WORKING_DIR=`pwd`
-export PATH="$WORKING_DIR/pio-engine/PredictionIO-dist/bin:$WORKING_DIR/pio-engine/PredictionIO-dist/sbt:$WORKING_DIR/PredictionIO-dist/bin:$WORKING_DIR/PredictionIO-dist/sbt:$PATH"
+export PATH="$WORKING_DIR/PredictionIO-dist/bin:$WORKING_DIR/PredictionIO-dist/sbt:$PATH"

--- a/.profile.d/pio-render-configs.sh
+++ b/.profile.d/pio-render-configs.sh
@@ -1,20 +1,20 @@
 #!/usr/bin/env bash
 
-core_site_template=pio-engine/PredictionIO-dist/conf/core-site.xml.erb
-elasticsearch_template=pio-engine/PredictionIO-dist/conf/elasticsearch.yml.erb
-spark_template=pio-engine/PredictionIO-dist/vendors/spark-hadoop/conf/spark-defaults.conf.erb
+core_site_template=PredictionIO-dist/conf/core-site.xml.erb
+elasticsearch_template=PredictionIO-dist/conf/elasticsearch.yml.erb
+spark_template=PredictionIO-dist/vendors/spark-hadoop/conf/spark-defaults.conf.erb
 
 if [ -f "$core_site_template" ]
 then
-  erb $core_site_template > pio-engine/PredictionIO-dist/conf/core-site.xml
+  erb $core_site_template > PredictionIO-dist/conf/core-site.xml
 fi
 
 if [ -f "$elasticsearch_template" ]
 then
-  erb $elasticsearch_template > pio-engine/PredictionIO-dist/conf/elasticsearch.yml
+  erb $elasticsearch_template > PredictionIO-dist/conf/elasticsearch.yml
 fi
 
 if [ -f "$spark_template" ]
 then
-  erb $spark_template > pio-engine/PredictionIO-dist/vendors/spark-hadoop/conf/spark-defaults.conf
+  erb $spark_template > PredictionIO-dist/vendors/spark-hadoop/conf/spark-defaults.conf
 fi

--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -230,7 +230,6 @@ Next, start a console & change to the engine's directory. This uses a paid, [pro
 
 ```bash
 heroku run bash --size Performance-L
-$ cd pio-engine/
 ```
 
 Then, start the process, specifying the evaluation & engine params classes from the `Evaluation.scala` source file. For example:

--- a/CUSTOM.md
+++ b/CUSTOM.md
@@ -36,6 +36,7 @@ Please, follow the steps in the order documented.
   1. [Re-deploy best parameters](#user-content-re-deploy-best-parameters)
 * [Eventserver](#user-content-eventserver) (optional)
   1. [Deploy the eventserver](#user-content-deploy-the-eventserver)
+* [Using pre-release features](#user-content-using-pre-release-features)
 * [Configuration](#user-content-configuration)
   * [Config files; `pio-env.sh`](#user-content-config-files)
   * [Environment variables](#user-content-environment-variables)
@@ -302,6 +303,25 @@ git push heroku-eventserver master
 ```
 
 Note that some add-ons, such as Bonsai Elasticsearch, do not officially support attaching to multiple apps. In these cases, their config var values must be manually copied & maintained between the engine to the eventserver.
+
+## Using pre-release features
+
+A SNAPSHOT distribution of PredictionIO is included with this buildpack, to support a few features that are ahead of the main PredictionIO release:
+
+* Authenticated Elasticsearch 5 client & various fixes (to support [Universal Recommender](https://github.com/heroku/predictionio-engine-ur))
+* Batch predictions with the new `pio batchpredict` command
+
+[Compare the SNAPSHOT branch](https://github.com/apache/incubator-predictionio/compare/develop...mars:esclient-auth-with-batch-predict) to see all changes.
+
+### Switch an engine to SNAPSHOT
+
+* **build.sbt**
+  * change: `"0.11.0-incubating"` to: `"0.11.0-SNAPSHOT"`
+  * append: `resolvers += "Buildpack Repository" at "file://"+baseDirectory.value+"/repo"`
+* **template.json**
+  * change: `"0.11.0-incubating"` to: `"0.11.0-SNAPSHOT"`
+
+These changes will make the engine use the snapshot build included in the buildpack's `repo/`.
 
 ## Configuration
 

--- a/DATA.md
+++ b/DATA.md
@@ -87,11 +87,10 @@ All three of these hooks work with the [batch import](https://predictionio.incub
 
 ```bash
 heroku run bash --size Performance-M
-$ cd pio-engine/
 $ ./data/create-sync-events
 $ pio app show $PIO_EVENTSERVER_APP_NAME
 # grab the ID of the app, replace `X` in next command
-$ pio import --appid X --input data/pio-engine/sync-events.json
+$ pio import --appid X --input data/sync-events.json
 ```
 
 ## REST API

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Enables data scientists and developers to deploy custom machine learning service
 
 This buildpack is part of an exploration into utilizing the [Heroku developer experience](https://www.heroku.com/dx) to simplify data science operations. When considering this proof-of-concept technology, please note its [current limitations](#user-content-limitations). We'd love to hear from you. [Open issues on this repo](https://github.com/heroku/predictionio-buildpack/issues) with feedback and questions.
 
+## Releases
+
+**July 31st, 2017**: merged a [potentially breaking change](https://github.com/heroku/predictionio-buildpack/pull/44) to make the buildpack composable with Python, Node, and other Heroku buildpacks. We don't anticipate issues for most buildpack users, but if this does effect you, please checkout the details in the [original pull request](https://github.com/heroku/predictionio-buildpack/pull/44).
+
+See [all releases](https://github.com/heroku/predictionio-buildpack/releases) with their changes.
+
 ## Engines
 
 Supports engines created for PredictionIO version:

--- a/bin/compile
+++ b/bin/compile
@@ -70,21 +70,7 @@ if [ -f "${BUILD_DIR}/engine.json" ]
 then
   topic "PredictionIO engine"
 
-  # Build with dyno runtime-compatible prefix.
-  # The PATH set in .profile.d/pio-env.sh must match.
-  # (`pio build` ends up capturing its absolute build path, so it needs
-  # to align with the actual runtime.)
-  app_namespace="pio-engine"
-  app_prefix="/app/${app_namespace}"
-  echo "Building at $app_prefix" | indent
-  STAGE_THE_BUILD=$CACHE_DIR/app-prefix-stage
-  mkdir -p $STAGE_THE_BUILD
-  mv $BUILD_DIR/* $STAGE_THE_BUILD/
-  mkdir -p $app_prefix
-  mv $STAGE_THE_BUILD/* $app_prefix/
-  rm -rf $STAGE_THE_BUILD
-  cd $app_prefix
-
+  cd $BUILD_DIR
   if [ "${PIO_VERBOSE:-}" = "true" ]
   then
     $PIO_DIST_NAME/bin/pio build --verbose | indent
@@ -93,46 +79,26 @@ then
     $PIO_DIST_NAME/bin/pio build | indent
   fi
 
-  echo "Clean-up build artifacts" | indent
-  # Try to keep slug below 300MB limit.
+  # Try to keep slug below 500MB limit.
   # This is based on profiling with
   # `du -a "${BUILD_DIR}" | sort -n -r | head -n 50`
   # and removing big objects that seem unnecessary.
   rm -rf "target/streams" || true
 
-  echo "Making engine available in runtime at /app/pio-engine/" | indent
-  # After PIO build at the runtime prefix, move the engine into the slug
-  mv $app_prefix $BUILD_DIR || true
-  # Move the Procfile(s) back to the top-level app directory or use default for engines
-  # (`bin/release` default_process_types have no effect since this is never the last buildpack)
-  if [ "${PIO_RUN_AS_EVENTSERVER:-false}" = "true" ]
+  # Move executables for Procfile into place
+  mkdir -p $BUILD_DIR/bin
+  cp $BP_DIR/bin/engine/heroku-* $BUILD_DIR/bin/
+
+  if [ -f "${BUILD_DIR}/Procfile" ]
+  then
+    echo "Using custom Procfile" | indent
+  elif [ "${PIO_RUN_AS_EVENTSERVER:-false}" = "true" ]
   then
     echo "Using eventserver Procfile" | indent
     cp "${BP_DIR}/Procfile-eventserver" "${BUILD_DIR}/Procfile"
-  elif [ -f "${BUILD_DIR}/${app_namespace}/Procfile" ]
-  then
-    echo "Using custom Procfile" | indent
-    mv $BUILD_DIR/$app_namespace/Procfile* $BUILD_DIR
   else
     echo "Using default Procfile for engine" | indent
     cp "${BP_DIR}/Procfile-engine" "${BUILD_DIR}/Procfile"
-  fi
-  # Move `.heroku` directory up to `/app/` to be composable
-  # with other buildpacks.
-  mv $BUILD_DIR/$app_namespace/.heroku $BUILD_DIR/ || true
-
-  echo "Making Procfile executables available in /app/bin/" | indent
-  mkdir -p $BUILD_DIR/bin
-  cp $BP_DIR/bin/engine/heroku-* $BUILD_DIR/bin/
-  # This supports composition with other buildpacks which might expect 
-  # bin/ & conf/ directories to stay in app/.
-  if [ -d "$BUILD_DIR/$app_namespace/bin" ]
-    then
-    mv $BUILD_DIR/$app_namespace/bin/* $BUILD_DIR/bin/
-  fi
-  if [ -d "$BUILD_DIR/$app_namespace/conf" ]
-    then
-    mv $BUILD_DIR/$app_namespace/conf/* $BUILD_DIR/conf/
   fi
 
 # The eventserver is built directly by the Scala buildpack.

--- a/bin/engine/heroku-buildpack-pio-load-data
+++ b/bin/engine/heroku-buildpack-pio-load-data
@@ -9,16 +9,15 @@ set -u
 # Debug, echo every command
 #set -x
 
-APP_PREFIX="pio-engine"
 BIN_PATH="bin" # because compile script moves bin/ up to app/
 CREATE_INITIAL_DATA_SCRIPT="data/create-initial-events"
-CREATE_INITIAL_DATA_SCRIPTPATH="$APP_PREFIX/$CREATE_INITIAL_DATA_SCRIPT"
+CREATE_INITIAL_DATA_SCRIPTPATH="$CREATE_INITIAL_DATA_SCRIPT"
 INITIAL_DATA_FILE="data/initial-events.json"
-INITIAL_DATA_FILEPATH="$APP_PREFIX/$INITIAL_DATA_FILE"
+INITIAL_DATA_FILEPATH="$INITIAL_DATA_FILE"
 SYNC_DATA_SCRIPT="data/create-sync-events"
-SYNC_DATA_SCRIPTPATH="$APP_PREFIX/$SYNC_DATA_SCRIPT"
+SYNC_DATA_SCRIPTPATH="$SYNC_DATA_SCRIPT"
 SYNC_DATA_FILE="data/sync-events.json"
-SYNC_DATA_FILEPATH="$APP_PREFIX/$SYNC_DATA_FILE"
+SYNC_DATA_FILEPATH="$SYNC_DATA_FILE"
 
 if [ -f "$CREATE_INITIAL_DATA_SCRIPTPATH" ] || [ -f "$INITIAL_DATA_FILEPATH" ] || [ -f "$SYNC_DATA_SCRIPTPATH" ]
 then
@@ -72,9 +71,6 @@ then
       echo "Fetching data using script '$CREATE_INITIAL_DATA_SCRIPT'."
       eval "$CREATE_INITIAL_DATA_SCRIPTPATH"
 
-      # Move the output file into the pio-engine/ prefix
-      mv $INITIAL_DATA_FILE $INITIAL_DATA_FILEPATH || true
-
       if [ ! -f "$INITIAL_DATA_FILEPATH" ]
         then
         echo "Error loading event data: '$CREATE_INITIAL_DATA_SCRIPT' did not produce the required output file '$INITIAL_DATA_FILE'."
@@ -94,9 +90,6 @@ then
       then
       echo "Fetching data using script '$SYNC_DATA_SCRIPT'."
       eval "$SYNC_DATA_SCRIPTPATH"
-
-      # Move the output file into the pio-engine/ prefix
-      mv $SYNC_DATA_FILE $SYNC_DATA_FILEPATH || true
 
       if [ -f "$SYNC_DATA_FILEPATH" ]
         then

--- a/bin/engine/heroku-buildpack-pio-train
+++ b/bin/engine/heroku-buildpack-pio-train
@@ -9,4 +9,4 @@ then
   S3_SUPPORT_OPTS="--driver-java-options '-Dcom.amazonaws.services.s3.enableV4' --conf 'spark.executor.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4'"
 fi
 
-eval "cd pio-engine/ && pio train ${PIO_OPTS:-} -- ${PIO_TRAIN_SPARK_OPTS:-} ${S3_SUPPORT_OPTS:-}"
+eval "pio train ${PIO_OPTS:-} -- ${PIO_TRAIN_SPARK_OPTS:-} ${S3_SUPPORT_OPTS:-}"

--- a/bin/engine/heroku-buildpack-pio-web
+++ b/bin/engine/heroku-buildpack-pio-web
@@ -27,4 +27,4 @@ then
   S3_SUPPORT_OPTS="--driver-java-options '-Dcom.amazonaws.services.s3.enableV4' --conf 'spark.executor.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4'"
 fi
 
-eval "cd pio-engine/ && pio deploy --port $PORT ${PIO_OPTS:-} ${FEEDBACK_OPTS:-} -- ${PIO_SPARK_OPTS:-} ${S3_SUPPORT_OPTS:-}"
+eval "pio deploy --port $PORT ${PIO_OPTS:-} ${FEEDBACK_OPTS:-} -- ${PIO_SPARK_OPTS:-} ${S3_SUPPORT_OPTS:-}"

--- a/bin/test
+++ b/bin/test
@@ -10,4 +10,4 @@ if [ -f "$PIO_ENV_FILE" ]
   source $PIO_ENV_FILE
 fi
 
-cd "/app/pio-engine" && ./PredictionIO-dist/sbt/sbt test
+./PredictionIO-dist/sbt/sbt test

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -13,4 +13,4 @@ fi
 eval "$(dirname ${0:-})/compile $1 $2 $3"
 
 echo "       Removing 'pio_env.sh' to override with test environment"
-rm "$1/pio-engine/PredictionIO-dist/conf/pio-env.sh"
+rm "$1/PredictionIO-dist/conf/pio-env.sh"

--- a/test/bin-engine-load-data_test.sh
+++ b/test/bin-engine-load-data_test.sh
@@ -9,7 +9,7 @@ pioCommandSpy=""
 afterSetUp() {
   PATH=./bin:$PATH
   appBinDir="$BUILD_DIR/bin"
-  appDataDir="$BUILD_DIR/pio-engine/data"
+  appDataDir="$BUILD_DIR/data"
   pioCommandSpy="${appBinDir}/pio"
   mkdir -p "${appBinDir}"
   mkdir -p "${appDataDir}"
@@ -234,7 +234,6 @@ HEREDOC
   capture ${BUILDPACK_HOME}/bin/engine/heroku-buildpack-pio-load-data
   assertEquals 1 ${rtrn}
   assertContains "did not produce the required output" "$(cat ${STD_OUT})"
-  assertContains "No such file" "$(cat ${STD_ERR})"
 }
 
 test_load_data_performs_sync()
@@ -333,5 +332,4 @@ HEREDOC
   capture ${BUILDPACK_HOME}/bin/engine/heroku-buildpack-pio-load-data
   assertEquals 0 ${rtrn}
   assertContains "did not produce the file" "$(cat ${STD_OUT})"
-  assertContains "No such file" "$(cat ${STD_ERR})"
 }

--- a/test/bin-engine-train_test.sh
+++ b/test/bin-engine-train_test.sh
@@ -8,7 +8,7 @@ pioSpy=""
 # to assert how it is called.
 afterSetUp() {
   PATH=./:$PATH
-  pioEngineDir="$BUILD_DIR/pio-engine"
+  pioEngineDir="$BUILD_DIR"
   pioSpy="${pioEngineDir}/pio"
   mkdir -p "${pioEngineDir}"
   cat > $pioSpy <<'HEREDOC'

--- a/test/bin-engine-web_test.sh
+++ b/test/bin-engine-web_test.sh
@@ -8,7 +8,7 @@ pioSpy=""
 # to assert how it is called.
 afterSetUp() {
   PATH=./:$PATH
-  pioEngineDir="$BUILD_DIR/pio-engine"
+  pioEngineDir="$BUILD_DIR"
   pioSpy="${pioEngineDir}/pio"
   mkdir -p "${pioEngineDir}"
   cat > $pioSpy <<'HEREDOC'

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -15,9 +15,9 @@ SKIP_test_compile_with_predictionio_0_10_0() {
 
   assertEquals "\`pio build\` exit code was ${RETURN} instead of 0" "0" "${RETURN}"
   assertTrue "missing Procfile" "[ -f $BUILD_DIR/Procfile ]"
-  assertTrue "missing PostgreSQL JDBC" "[ -f $BUILD_DIR/pio-engine/PredictionIO-dist/lib/postgresql_jdbc.jar ]"
-  assertTrue "missing AWS SDK" "[ -f $BUILD_DIR/pio-engine/PredictionIO-dist/lib/spark/aws-java-sdk.jar ]"
-  assertTrue "missing Hadoop-AWS" "[ -f $BUILD_DIR/pio-engine/PredictionIO-dist/lib/spark/hadoop-aws.jar ]"
+  assertTrue "missing PostgreSQL JDBC" "[ -f $BUILD_DIR/PredictionIO-dist/lib/postgresql_jdbc.jar ]"
+  assertTrue "missing AWS SDK" "[ -f $BUILD_DIR/PredictionIO-dist/lib/spark/aws-java-sdk.jar ]"
+  assertTrue "missing Hadoop-AWS" "[ -f $BUILD_DIR/PredictionIO-dist/lib/spark/hadoop-aws.jar ]"
   assertTrue "missing runtime memory config" "[ -f $BUILD_DIR/.profile.d/pio-memory.sh ]"
   assertTrue "missing runtime path config" "[ -f $BUILD_DIR/.profile.d/pio-path.sh ]"
   assertTrue "missing runtime config renderer" "[ -f $BUILD_DIR/.profile.d/pio-render-configs.sh ]"
@@ -25,12 +25,12 @@ SKIP_test_compile_with_predictionio_0_10_0() {
   assertTrue "missing train executable" "[ -f $BUILD_DIR/bin/heroku-buildpack-pio-train ]"
   assertTrue "missing release executable" "[ -f $BUILD_DIR/bin/heroku-buildpack-pio-release ]"
   assertTrue "missing data loader executable" "[ -f $BUILD_DIR/bin/heroku-buildpack-pio-load-data ]"
-  expected_output="$BUILD_DIR/pio-engine/target/scala-2.10/template-scala-parallel-classification-assembly-0.1-SNAPSHOT-deps.jar"
+  expected_output="$BUILD_DIR/target/scala-2.10/template-scala-parallel-classification-assembly-0.1-SNAPSHOT-deps.jar"
   assertTrue "missing Scala build output: $expected_output" "[ -f $expected_output ]"
 
-  echo "-----> Stage build for testing in /app/pio-engine (same as dyno runtime)"
+  echo "-----> Stage build for testing in /app (same as dyno runtime)"
   mv $BUILD_DIR/* $BUILD_DIR/.[!.]* /app/
-  cd /app/pio-engine
+  cd /app
 
   capture ./PredictionIO-dist/bin/pio status
 
@@ -60,9 +60,9 @@ SKIP_test_compile_with_predictionio_0_11_0() {
 
   assertEquals "\`pio build\` exit code was ${RETURN} instead of 0" "0" "${RETURN}"
   assertTrue "missing Procfile" "[ -f $BUILD_DIR/Procfile ]"
-  assertTrue "missing PostgreSQL JDBC" "[ -f $BUILD_DIR/pio-engine/PredictionIO-dist/lib/postgresql_jdbc.jar ]"
-  assertTrue "missing AWS SDK" "[ -f $BUILD_DIR/pio-engine/PredictionIO-dist/lib/spark/aws-java-sdk.jar ]"
-  assertTrue "missing Hadoop-AWS" "[ -f $BUILD_DIR/pio-engine/PredictionIO-dist/lib/spark/hadoop-aws.jar ]"
+  assertTrue "missing PostgreSQL JDBC" "[ -f $BUILD_DIR/PredictionIO-dist/lib/postgresql_jdbc.jar ]"
+  assertTrue "missing AWS SDK" "[ -f $BUILD_DIR/PredictionIO-dist/lib/spark/aws-java-sdk.jar ]"
+  assertTrue "missing Hadoop-AWS" "[ -f $BUILD_DIR/PredictionIO-dist/lib/spark/hadoop-aws.jar ]"
   assertTrue "missing runtime memory config" "[ -f $BUILD_DIR/.profile.d/pio-memory.sh ]"
   assertTrue "missing runtime path config" "[ -f $BUILD_DIR/.profile.d/pio-path.sh ]"
   assertTrue "missing runtime config renderer" "[ -f $BUILD_DIR/.profile.d/pio-render-configs.sh ]"
@@ -70,12 +70,12 @@ SKIP_test_compile_with_predictionio_0_11_0() {
   assertTrue "missing train executable" "[ -f $BUILD_DIR/bin/heroku-buildpack-pio-train ]"
   assertTrue "missing release executable" "[ -f $BUILD_DIR/bin/heroku-buildpack-pio-release ]"
   assertTrue "missing data loader executable" "[ -f $BUILD_DIR/bin/heroku-buildpack-pio-load-data ]"
-  expected_output="$BUILD_DIR/pio-engine/target/scala-2.11/template-scala-parallel-classification-assembly-0.1-SNAPSHOT-deps.jar"
+  expected_output="$BUILD_DIR/target/scala-2.11/template-scala-parallel-classification-assembly-0.1-SNAPSHOT-deps.jar"
   assertTrue "missing Scala build output: $expected_output" "[ -f $expected_output ]"
 
-  echo "-----> Stage build for testing in /app/pio-engine (same as dyno runtime)"
+  echo "-----> Stage build for testing in /app (same as dyno runtime)"
   mv $BUILD_DIR/* $BUILD_DIR/.[!.]* /app/
-  cd /app/pio-engine
+  cd /app
 
   capture ./PredictionIO-dist/bin/pio status
 


### PR DESCRIPTION
This changeset removes an old filesystem path workaround for Heroku compatibility that is no longer required. That workaround causes issues composing this buildpack with other buildpacks, like Python or Node.

🚨 **This is a potentially breaking change for PredictionIO deployments that include custom scripts that reference the absolute `/app/pio-engine` or relative `./pio-engine` path.** The `pio-engine` prefix is no longer used, so all references should be `/app` or `./`, the default working directory. Most deployments will not be affected by this underlying build & runtime change.

### Background

During the early days of this buildpack when PredictionIO 0.9.5 was the supported version, the `pio build` command was not compatible with Heroku. We implemented a workaround to perform the build at a stable path prefix. Since then, PredictionIO itself has been fixed to avoid this problem.

### Try It Out

List current buildpacks:

```bash
heroku buildpacks
```

Then, set this buildpack to use this branch:

✏️ *Replace `$N` with the position number of this buildpack in the list.*

```bash
heroku buildpacks:set -i $N https://github.com/heroku/predictionio-buildpack.git#stable-path
```

Now, deploy/train/release to verify that it works as expected:

```bash
git commit --allow-empty -m 'Deploy to test buildpack stable-path'
git push heroku master
```

### This broke my engine!

Please do one of the following:

* remove the `pio-engine` path segment from the filesystem path references in your scripts
* switch back to the previous version of the buildpack

    ```bash
    heroku buildpacks:set https://github.com/heroku/predictionio-buildpack.git#v8.3.0
    ```

💬 Please leave a comment here with 👍/👎 feedback.
